### PR TITLE
updating customer_type

### DIFF
--- a/models/transform/customers.sql
+++ b/models/transform/customers.sql
@@ -20,7 +20,7 @@ joined as (
         orders.lifetime_completed_orders,
         orders.lifetime_revenue,
         orders.customer_age_days,
-        orders.customer_type,
+        coalesce(orders.customer_type, 'non_purchaser') as customer_type,
         orders.customer_first_30_day_completed_orders,
         orders.customer_first_30_day_revenue,
         orders.customer_first_60_day_completed_orders,


### PR DESCRIPTION
* customer_type is supposed to explain if a customer is a "single purchaser", "repeat purchaser" or has never purchased
* the lack of coalesce when joining from orders means that non purchasing customers weren't correctly being identified