### PR TITLE
Fix: Removed relationship test from orders and customers

### DIFF
--- a/models/transform/schema.yml
+++ b/models/transform/schema.yml
@@ -45,9 +45,7 @@ models:
     - not_null
   - name: customer_id
     tests:
-    - relationships:
-        field: customer_id
-        to: ref('customers')
+    - not_null
   - name: email
     tests:
     - not_null


### PR DESCRIPTION
Removed `relationships` test from `orders_xf` that relates to the `customers` model on the `customer_id` field; kept `not_null` test

Ran and passed schema tests