### PR TITLE
updating test

### DIFF
--- a/models/transform/schema.yml
+++ b/models/transform/schema.yml
@@ -23,7 +23,7 @@ models:
     tests:
     - relationships:
         field: order_id
-        to: ref('orders')
+        to: ref('orders_xf')
   - name: order_item_id
     tests:
     - not_null


### PR DESCRIPTION
### updating schema test

* `order_items` refed `orders` for a relationship text but there isn't an `orders` table 
* newest version of dbt told me this test was causing a warning