### PR TITLE
coalesce total price to 0 for lifetime revenue

### DIFF
--- a/models/transform/orders_calculations.sql
+++ b/models/transform/orders_calculations.sql
@@ -78,7 +78,7 @@ calculation_1 as (
         count(*) over (partition by {{var('customer_aggregate_on')}})
             as lifetime_placed_orders,
         
-        sum(total_price) {{frame_clause}} as lifetime_revenue,
+        sum(coalesce(total_price, 0)) {{frame_clause}} as lifetime_revenue,
         
         --completed order values
 


### PR DESCRIPTION
* Sometimes, there are occasions where the total price is null because the payment hasn't processed yet.