### PR TITLE
Feature/select timerange

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Requires dbt >= 0.12.2
 
+## Installation Instructions
+Check [dbt Hub](https://hub.getdbt.com/fishtown-analytics/snowplow/latest/) for
+the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management)
+for more information on installing packages.
+
 ## Required Columns
 
 Structure your orders model that feeds into the ecommerce package such that it has the following columns and column names:
@@ -11,9 +16,40 @@ Structure your orders model that feeds into the ecommerce package such that it h
 - email (or other unique id) associated with order: **email**
 - binary value for whether the order should be included for completed orders and revenue: **is_completed**
 
+## Configuration ###
+
+The [variables](https://docs.getdbt.com/docs/using-variables) needed to configure this package are as follows:
+
+| variable | information | required |
+|----------|-------------|:--------:|
+|customer_aggregate_on| Used to partition orders by to create common metrics (like time between orders).|Yes|
+|customer_join_on| Used to join customers and orders tables. This may be different that the field to aggregate depending on the structure of the data. |Yes|
+|days|This accepts a list of days to calculate customers_first_x_day_revenue and order values. This will return the revenue or number of orders that user places in their first x days. |Yes|
+
+
+An example `dbt_project.yml` configuration:
+
+```yml
+# dbt_project.yml
+
+...
+
+models:
+    fishtown_analytics_ecommerce:
+        vars:
+          addresses_table: "{{ref('stg_addresses')}}"
+          customers_table: "{{ref('stg_customers')}}"
+          order_items_table: "{{ref('stg_order_items')}}"
+          orders_table: "{{ref('stg_orders')}}"
+          products_table: "{{ref('stg_products')}}"
+          customer_aggregate_on: customer_id
+          customer_join_on: customer_id
+          days: ['30', '60', '90', '365']
+```
+
 ---
 - [What is dbt](https://dbt.readme.io/docs/overview)?
 - Read the [dbt viewpoint](https://dbt.readme.io/docs/viewpoint)
 - [Installation](https://dbt.readme.io/docs/installation)
-- Join the [chat](http://ac-slackin.herokuapp.com/) on Slack for live questions and support.Â
+- Join the [chat](http://ac-slackin.herokuapp.com/) on Slack for live questions and support.
 ---

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -9,3 +9,15 @@ target-path: "target"
 clean-targets:
     - "target"
     - "dbt_modules"
+
+models: 
+  fishtown_analytics_ecommerce:
+    vars:
+      addresses_table: TABLE OR {{ REF }}
+      customers_table: TABLE OR {{ REF }}
+      order_items_table: TABLE OR {{ REF }}
+      orders_table: TABLE OR {{ REF }}
+      products_table: TABLE OR {{ REF }}
+      customer_aggregate_on: customer_id or email
+      customer_join_on: customer_id or email
+      days: []

--- a/macros/first_window_values.sql
+++ b/macros/first_window_values.sql
@@ -1,0 +1,37 @@
+{% macro first_window_values(days) %}
+
+    {% for day in days %}
+    
+
+        sum(case when days_from_first_completed_order <= {{ day }} 
+            and is_completed = 1
+            then 1 else 0 end)
+            over (partition by {{var('customer_aggregate_on')}} 
+            order by created_at rows between unbounded preceding and unbounded following)
+            as customer_first_{{ day }}_day_completed_orders,
+
+        sum(case when days_from_first_completed_order <= {{ day }} 
+            and is_completed = 1
+            then total_price else 0 end)
+            over (partition by {{var('customer_aggregate_on')}} 
+            order by created_at rows between unbounded preceding and unbounded following)
+            as customer_first_{{ day }}_day_revenue
+            
+        {% if not loop.last%} , {% endif %}
+            
+    {% endfor %}
+    
+{% endmacro %}
+
+{% macro customer_values(days) %}
+    
+    {% for day in days %}
+    
+        orders.customer_first_{{ day }}_day_completed_orders,
+        orders.customer_first_{{ day }}_day_revenue
+        
+        {% if not loop.last%} , {% endif %}
+        
+    {% endfor %}
+
+{% endmacro %}

--- a/models/transform/customers.sql
+++ b/models/transform/customers.sql
@@ -1,15 +1,23 @@
 with customers as (
 
     select * from {{var('customers_table')}}
+
 ),
 
 orders as (
 
     select * from {{ref('orders_xf')}}
     where order_seq_number = 1
+
 ),
 
 joined as (
+    
+    {% set days = 
+
+        var('days')
+    
+    %}
 
     select
 
@@ -21,15 +29,12 @@ joined as (
         orders.lifetime_revenue,
         orders.customer_age_days,
         coalesce(orders.customer_type, 'non_purchaser') as customer_type,
-        orders.customer_first_30_day_completed_orders,
-        orders.customer_first_30_day_revenue,
-        orders.customer_first_60_day_completed_orders,
-        orders.customer_first_60_day_revenue,
-        orders.customer_first_90_day_completed_orders,
-        orders.customer_first_90_day_revenue
+        
+        {{ customer_values (days = days) }}
 
     from customers
     left join orders using ({{var('customer_join_on')}})
+
 )
 
 select * from joined

--- a/models/transform/orders_calculations.sql
+++ b/models/transform/orders_calculations.sql
@@ -60,6 +60,7 @@ order_numbers as (
         end as new_vs_repeat
 
     from fields
+    
 ),
 
 calculation_1 as (
@@ -171,6 +172,12 @@ date_diffs as (
 
 final_calculations as (
 
+    {% set days = 
+
+        var('days')
+    
+    %}
+
     select
 
         *,
@@ -180,35 +187,7 @@ final_calculations as (
             else 'non_purchaser'
         end as customer_type,
 
-        sum(case when days_from_first_completed_order <= 30 and is_completed = 1
-            then 1 else 0 end)
-            {{ frame_clause }}
-            as customer_first_30_day_completed_orders,
-
-        sum(case when days_from_first_completed_order <= 30 and is_completed = 1
-            then total_price else 0 end)
-            {{ frame_clause }}
-        as customer_first_30_day_revenue,
-
-        sum(case when days_from_first_completed_order <= 60 and is_completed = 1
-            then 1 else 0 end)
-            {{ frame_clause }}
-            as customer_first_60_day_completed_orders,
-
-        sum(case when days_from_first_completed_order <= 60 and is_completed = 1
-            then total_price else 0 end)
-            {{ frame_clause }}
-            as customer_first_60_day_revenue,
-
-        sum(case when days_from_first_completed_order <= 90 and is_completed = 1
-            then 1 else 0 end)
-            {{ frame_clause }}
-            as customer_first_90_day_completed_orders,
-
-        sum(case when days_from_first_completed_order <= 90 and is_completed = 1
-            then total_price else 0 end)
-            {{ frame_clause }}
-            as customer_first_90_day_revenue
+        {{ first_window_values ( days = days ) }}
 
     from date_diffs
     


### PR DESCRIPTION
### Summary

The `order_calculations` model creates values for `customer_first_x_day_revenue ` and `customer_first_x_day_completed_orders`. These have traditionally been set for 30, 60 and 90 days but often people want to customize this (365 days, etc)

* add macro to loop over listed day values - supplied as `var`
* add macro to add these fields to the customers model
* add to README to document the change (and add information for which vars the project requires)
* add example in `project.yml` file

Tested and passed on Snowflake.

There are a few things that this package could use in future updates but this gets us closer for this use case!