### PR TITLE
fix new repeat segmentation

### DIFF
--- a/models/transform/customers.sql
+++ b/models/transform/customers.sql
@@ -27,6 +27,7 @@ joined as (
         orders.lifetime_placed_orders,
         orders.lifetime_completed_orders,
         orders.lifetime_revenue,
+        orders.lifetime_completed_revenue,
         orders.customer_age_days,
         coalesce(orders.customer_type, 'non_purchaser') as customer_type,
         

--- a/models/transform/orders_calculations.sql
+++ b/models/transform/orders_calculations.sql
@@ -61,9 +61,9 @@ order_numbers as (
         *,
         
         case
-            when completed_order_number is null then null
             when completed_order_number = 1 then 'new'
-            else 'repeat'
+            when completed_order_number is not null then 'repeat'
+            else null
         end as new_vs_repeat
 
     from fields

--- a/models/transform/orders_calculations.sql
+++ b/models/transform/orders_calculations.sql
@@ -61,8 +61,8 @@ order_numbers as (
         *,
         
         case
-            when completed_order_number = 1
-                then 'new'
+            when completed_order_number is null then null
+            when completed_order_number = 1 then 'new'
             else 'repeat'
         end as new_vs_repeat
 


### PR DESCRIPTION
### Summary

This solves a small fix: most `orders` tables are one row per order. Some systems, however, have `carts`, `exchanges`, `returns`, etc all in the orders table and we do NOT want to categorize these as `repeat`. This fixes this issue!

NOTE: I also added a quick addition of `lifetime_completed_revenue` to `customers` since previously this summed all revenue regardless of completeness

